### PR TITLE
Upgrading datatables version to 1.10.24 #2

### DIFF
--- a/DataTables.Blazor.Demo/libman.json
+++ b/DataTables.Blazor.Demo/libman.json
@@ -3,12 +3,16 @@
   "defaultProvider": "cdnjs",
   "libraries": [
     {
-      "library": "datatables@1.10.21",
-      "destination": "wwwroot//lib/datatables/"
+      "library": "datatables.net-dt@1.10.24",
+      "destination": "wwwroot/lib/datatables/"
+    },
+    {
+      "library": "datatables.net@1.10.24",
+      "destination": "wwwroot/lib/datatables.net/"
     },
     {
       "library": "jquery@3.5.1",
       "destination": "wwwroot/lib/jquery/"
     }
-  ]
+]
 }

--- a/DataTables.Blazor.Demo/wwwroot/index.html
+++ b/DataTables.Blazor.Demo/wwwroot/index.html
@@ -21,7 +21,7 @@
     </div>
     <script src="_framework/blazor.webassembly.js"></script>
     <script src="lib/jquery/jquery.min.js"></script>
-    <script src="lib/datatables/js/jquery.dataTables.min.js"></script>
+    <script src="lib/datatables.net/jquery.dataTables.min.js"></script>
     <script src="_content/DataTables.Blazor/datatables.blazor.min.js"></script>
 </body>
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A basic port for jquery [DataTables](https://datatables.net/) into Blazor.
 
 #### Setup:
 ##### Prerequisites:
-You will need to include jquery Datatables in your project, some of the options are not available to older versions so to be on the safe side, v1.10.21 would be best.
+You will need to include jquery Datatables in your project, some of the options are not available to older versions so to be on the safe side, v1.10.24 would be best.
 Steps to complete can be found [here](https://datatables.net/manual/installation).
 
 ##### Configuration:


### PR DESCRIPTION
Prior to this update, we were using the cdnjs package called _datatables_.  That cdnjs package [points to](https://github.com/cdnjs/packages/blob/master/packages/d/datatables.json) the [Datatables/Datables repository](https://github.com/DataTables/DataTables) on GitHub, and that repository [had it's last release](https://github.com/DataTables/DataTables/commits/master) almost a year ago.  Because of that, the _datatables_ cdnjs package is unlikely to see further updates.

Instead, we're now pointing to the [_datatables.net_ package](https://github.com/cdnjs/packages/blob/master/packages/d/datatables.net.json) on cdnjs for the javascript file and the [_datatables.net-dt_ package](https://github.com/cdnjs/packages/blob/master/packages/d/datatables.net-dt.json) on cdnjs for the css file.  

Those packages continue to have regular updates, which allows us to use them to upgrade DataTables.Blazor to 1.10.24.