### PR TITLE
Element reference

### DIFF
--- a/DataTables.Blazor.Demo/Pages/Index.razor
+++ b/DataTables.Blazor.Demo/Pages/Index.razor
@@ -4,7 +4,7 @@
 
 <p>This component demonstrates use of a DataTable</p>
 
-<DataTable Id="MyTable" SourceUrl="sample-data/weather.json" Class="table table-striped table-bordered w-100">
+<DataTable SourceUrl="sample-data/weather.json" Class="table table-striped table-bordered w-100">
     <Column Title="Date" Data="Date" />
     <Column Title="Temp. (C)" Data="TemperatureC" />
     <Column Title="Summary" ClassName="dt-body-center" Data="Summary" />

--- a/DataTables.Blazor/DataTable.razor
+++ b/DataTables.Blazor/DataTable.razor
@@ -10,13 +10,13 @@
 </CascadingValue>
 
 @code{
+    [Parameter]
+    public RenderFragment ChildContent { get; set; }
+
     private ElementReference TableReference;
 
     [Parameter(CaptureUnmatchedValues = true)]
     public Dictionary<string, object> TableAttributes { get; set; }
-
-    [Parameter]
-    public RenderFragment ChildContent { get; set; }
 
     [Parameter]
     public string SourceUrl { get; set; }

--- a/DataTables.Blazor/DataTable.razor
+++ b/DataTables.Blazor/DataTable.razor
@@ -1,7 +1,7 @@
 ﻿@inject DataTablesInterop Datatables
 
 <CascadingValue Value="this">
-    <table id="@Id" class="@Class" style="@Style">
+    <table @ref="TableReference" @attributes=TableAttributes>
         <thead>
             <tr>@ChildContent</tr>
         </thead>
@@ -10,17 +10,13 @@
 </CascadingValue>
 
 @code{
+    private ElementReference TableReference;
+
+    [Parameter(CaptureUnmatchedValues = true)]
+    public Dictionary<string, object> TableAttributes { get; set; }
+
     [Parameter]
     public RenderFragment ChildContent { get; set; }
-
-    [Parameter]
-    public string Id { get; set; }
-
-    [Parameter]
-    public string Class { get; set; }
-
-    [Parameter]
-    public string Style { get; set; }
 
     [Parameter]
     public string SourceUrl { get; set; }
@@ -34,7 +30,7 @@
     {
         if (firstRender)
         {
-            await Datatables.InitialiseAsync(Id, DataTableOptions.FromComponent(this));
+            await Datatables.InitialiseAsync(TableReference, DataTableOptions.FromComponent(this));
         }
     }
 }

--- a/DataTables.Blazor/DataTables.Blazor.csproj
+++ b/DataTables.Blazor/DataTables.Blazor.csproj
@@ -6,12 +6,17 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
-    <Version>0.1.1</Version>
+    <Version>0.1.2</Version>
     <Description>A basic port for jquery DataTables into Blazor.</Description>
     <Copyright>Justin Wilkinson (2020)</Copyright>
     <Authors>Justin Wilkinson</Authors>
     <Company />
 	<RepositoryUrl>https://github.com/JustinWilkinson/DataTables.Blazor</RepositoryUrl>
+	<PackageReleaseNotes>Removed the need for users of DataTables.Blazor to add an ID element. Instead we use an ElementReference - where Blazor gives us a variable that is assigned the element itself, which can be handed to JS Interop.
+
+Also, instead of specifying Class and Style as two attributes that can be passed to the Table element, we allow any attributes to be passed down by catching all attributes (e.g., parameters) that don't have a match in the DataTable component.
+
+The ID can (optionally) still be assigned to the DataTable component, and if it is, it will be rendered as the id of the table element.</PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>

--- a/DataTables.Blazor/DatatablesInterop.cs
+++ b/DataTables.Blazor/DatatablesInterop.cs
@@ -1,4 +1,5 @@
 using DataTables.Blazor.Options;
+using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop;
 using System.Text.Json;
 using System.Threading.Tasks;
@@ -40,14 +41,14 @@ namespace DataTables.Blazor
         }
 
         /// <summary>
-        /// Initialises a DataTable with the provided options on the element with the provided id.
+        /// Initialises a DataTable with the provided options on the provided element.
         /// </summary>
-        /// <param name="id">Id of element to add DataTable to.</param>
+        /// <param name="tableReference">Reference of element to add DataTable to.</param>
         /// <param name="options">Options for DataTable.</param>
         /// <returns></returns>
-        public async ValueTask InitialiseAsync(string id, DataTableOptions options)
+        public async ValueTask InitialiseAsync(ElementReference tableReference, DataTableOptions options)
         {
-            await _runtime.InvokeVoidAsync("datatablesInterop.initialiseDataTable", id, JsonSerializer.Serialize(options, _serializerOptions));
+            await _runtime.InvokeVoidAsync("datatablesInterop.initialiseDataTable", tableReference, JsonSerializer.Serialize(options, _serializerOptions));
         }
     }
 }

--- a/DataTables.Blazor/wwwroot/datatables.blazor.js
+++ b/DataTables.Blazor/wwwroot/datatables.blazor.js
@@ -1,3 +1,5 @@
 window.datatablesInterop = {
-    initialiseDataTable: (id, options) => { $(`#${id}`).DataTable(JSON.parse(options)); }
+    initialiseDataTable: (tableElement, options) => {
+        $(tableElement).DataTable(JSON.parse(options));
+    }
 };

--- a/DataTables.Blazor/wwwroot/datatables.blazor.min.js
+++ b/DataTables.Blazor/wwwroot/datatables.blazor.min.js
@@ -1,1 +1,1 @@
-window.datatablesInterop={initialiseDataTable:(n,t)=>{$(`#${n}`).DataTable(JSON.parse(t))}};
+window.datatablesInterop={initialiseDataTable:(n,t)=>{$(n).DataTable(JSON.parse(t))}};

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ You should now be ready to get started with DataTables.Blazor!
 * This is then transformed into a jquery DataTable configured with the DataTable defaults.
 As is shown in the demo, adding a datatable is then as easy as adding the below to your page/component.
 ```html
-<DataTable Id="MyTable" SourceUrl="sample-data/weather.json" Class="table table-striped table-bordered w-100">
+<DataTable SourceUrl="sample-data/weather.json" Class="table table-striped table-bordered w-100">
     <Column Title="Date" Data="Date" />
     <Column Title="Temp. (C)" Data="TemperatureC" />
     <Column Title="Summary" ClassName="dt-body-center" Data="Summary" />


### PR DESCRIPTION
Remove the need for users of DataTables.Blazor to add an ID element.  Instead we use an ElementReference - where Blazor gives us a variable that is assigned the element itself, which can be handed to JS Interop.

Also, instead of specifying Class and Style as two attributes that can be passed to the Table element, we allow any attributes to be passed down by catching all attributes (e.g., parameters) that don't have a match in the DataTable component.

The ID can (optionally) still be assigned to the DataTable component, and if it is, it will be rendered as the id of the table element.